### PR TITLE
[fix] isospin name 'nan' is not defined

### DIFF
--- a/nuclr/data.py
+++ b/nuclr/data.py
@@ -231,7 +231,7 @@ def get_stability_from(string):
 
 @apply_to_df_col("isospin")
 def get_isospin_from(string):
-    return float(eval(string.replace(" ", "float('nan')")))
+    return float(eval(string.replace(" ", "nan"), {"nan": float('nan')}))
 
 
 def get_binding_energy_from(df):


### PR DESCRIPTION
Trying to load the spiral model (ai-nuclear-nn_test_long_run)... In function prepare_nuclear_data, the following issue was present when executing the isospin cleaning:

```
File /mnt/d/workspace/NuCLR_interp/nuclr/data.py:465, in prepare_nuclear_data(config, recreate)

@apply_to_df_col("isospin")
def get_isospin_from(string):
--> 254     return float(eval(string.replace(" ", "float('nan')")))

File <string>:1
NameError: name 'nan' is not defined
```

Solved it with this:

```
@apply_to_df_col("isospin")
def get_isospin_from(string):
    return float(eval(string.replace(" ", "nan"), {"nan": float('nan')}))
```

Not sure if it was a real bug or something env specific.

@niklasnolte @trifinos @okitouni 